### PR TITLE
👌 IMPROVE: Add option to disable line break

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,25 +22,27 @@ module.exports = options => {
 	const defaultOptions = {
 		type: `error`,
 		msg: `You forgot to define all options.`,
-		name: ``
+		name: ``,
+		lineBreak: true
 	};
 	const opts = {...defaultOptions, ...options};
 	const {type, msg, name} = opts;
 	const printName = name ? name : type.toUpperCase();
+	const lineBreak = opts.lineBreak ? `\n` : ``;
 
 	if (type === `success`) {
-		console.log(`\n${sym.success} ${greenI(` ${printName} `)} ${green(msg)}\n`);
+		console.log(`${lineBreak}${sym.success} ${greenI(` ${printName} `)} ${green(msg)}${lineBreak}`);
 	}
 
 	if (type === `warning`) {
-		console.log(`\n${sym.warning} ${orangeI(` ${printName} `)} ${orange(msg)}\n`);
+		console.log(`${lineBreak}${sym.warning} ${orangeI(` ${printName} `)} ${orange(msg)}${lineBreak}`);
 	}
 
 	if (type === `info`) {
-		console.log(`\n${sym.info} ${blueI(` ${printName} `)} ${blue(msg)}\n`);
+		console.log(`${lineBreak}${sym.info} ${blueI(` ${printName} `)} ${blue(msg)}${lineBreak}`);
 	}
 
 	if (type === `error`) {
-		console.log(`\n${sym.error} ${redI(` ${printName} `)} ${red(msg)}\n`);
+		console.log(`${lineBreak}${sym.error} ${redI(` ${printName} `)} ${red(msg)}${lineBreak}`);
 	}
 };


### PR DESCRIPTION
### Overview
This pull request proposes adding a new option parameter that allows enabling or disabling line breaks on the output. This will provide developers with more control over the formatting of console logs in their applications.

### Motivation
Console logs are a critical part of debugging and understanding code behavior. However, in some cases, the default formatting of console logs can be difficult to read and understand, especially when dealing with large amounts of output. Providing the option to disable line breaks can help to improve the readability of console logs in these cases.

### Changes Made
This pull request adds a new optional parameter called lineBreack. When set to false, this parameter will disable line breaks on the output. When set to true or not provided, the line break will apear as normally does.

### Impact
This change should have no negative impact on existing code. The new parameter is optional, and the default behavior of alert remains unchanged.